### PR TITLE
issue-16: Added resuable toast component in login and register page

### DIFF
--- a/src/components/toast/toast.jsx
+++ b/src/components/toast/toast.jsx
@@ -1,0 +1,20 @@
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export default function Toast({ type, message, dismissError }) {
+  const cls =
+    type === 'error'
+      ? 'bg-red-100 border-l-4 border-red-500 text-red-700'
+      : 'bg-green-100 border-l-4 border-green-500 text-green-700 my-2';
+  return (
+    <div className={`${cls} p-4 mb-4 flex justify-between`}>
+      <p>{message}</p>
+      <FontAwesomeIcon
+        onClick={() => dismissError()}
+        className="text-red-500 hover:text-red-700 ml-2"
+        icon={faXmark}
+        size="lg"
+      />
+    </div>
+  );
+}

--- a/src/components/toast/toast.jsx
+++ b/src/components/toast/toast.jsx
@@ -2,12 +2,12 @@ import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export default function Toast({ type, message, dismissError }) {
-  const cls =
-    type === 'error'
-      ? 'bg-red-100 border-l-4 border-red-500 text-red-700'
-      : 'bg-green-100 border-l-4 border-green-500 text-green-700 my-2';
+  const typeToClassMap = {
+    error: 'bg-red-100 border-l-4 border-red-500 text-red-700',
+    success: 'bg-green-100 border-l-4 border-green-500 text-green-700 my-2',
+  };
   return (
-    <div className={`${cls} p-4 mb-4 flex justify-between`}>
+    <div className={`${typeToClassMap[type]} p-4 mb-4 flex justify-between`}>
       <p>{message}</p>
       <FontAwesomeIcon
         onClick={() => dismissError()}

--- a/src/routes/login/Login.jsx
+++ b/src/routes/login/Login.jsx
@@ -4,9 +4,8 @@ import { networkAdapter } from 'services/NetworkAdapter';
 import React, { useContext } from 'react';
 import { AuthContext } from 'contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
-import { faXmark } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import validations from 'utils/validations';
+import Toast from 'components/toast/toast';
 
 /**
  * Login Component
@@ -97,15 +96,11 @@ const Login = () => {
               />
             </div>
             {errorMessage && (
-              <div className="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 mb-4 flex justify-between">
-                <p>{errorMessage}</p>
-                <FontAwesomeIcon
-                  onClick={dismissError}
-                  className="text-red-500 hover:text-red-700 ml-2"
-                  icon={faXmark}
-                  size="lg"
-                />
-              </div>
+              <Toast
+                type="error"
+                message={errorMessage}
+                dismissError={dismissError}
+              />
             )}
             <div className="bg-slate-50 my-4 p-3 flex flex-col">
               <small className="text-slate-600">test user details</small>

--- a/src/routes/register/Register.jsx
+++ b/src/routes/register/Register.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { networkAdapter } from 'services/NetworkAdapter';
 import { useNavigate } from 'react-router-dom';
+import Toast from 'components/toast/toast';
 
 /**
  * Register Component
@@ -140,9 +141,7 @@ const Register = () => {
               </Link>
             </div>
             {showSuccess && (
-              <div className="bg-green-100 border-l-4 border-green-500 text-green-700 p-4 mb-4 my-2">
-                <p>{successMessage}</p>
-              </div>
+              <Toast type="success" message={successMessage} dismissError />
             )}
           </form>
         </div>


### PR DESCRIPTION
## Type of Change
<!-- Replace the space with an 'x' in the appropriate box and delete other options. -->
<!-- example: [x] Feat: added new route for /login page -->
- [ ] Bug: [Title]
- [feat] Feat: Added resuable toast component in login and register page
- [ ] Doc: [Title]
- [ ] Test: [Title]
- [ ] CI: [Title]

## Description
<!-- Briefly describe the changes you've made. -->
Created a reusable component called Toast with params message and type. The type will be passed success or error string which will be used to display the relevant message style

## Linked Issue
<!-- If applicable, link the issue number that this PR closes. Use the format: #ISSUE_NUMBER -->
https://github.com/iZooGooD/stay-booker-hotel-booking-react-frontend/issues/16

## Screenshots
<!-- Attach any screenshots or visuals that highlight the changes. -->
![image](https://github.com/iZooGooD/stay-booker-hotel-booking-react-frontend/assets/26416009/950bf852-d1ea-48e7-8cc8-4868a7bf8d46)

![image](https://github.com/iZooGooD/stay-booker-hotel-booking-react-frontend/assets/26416009/53a1b283-9188-476e-849e-346b5b300cf8)

## Tests
<!-- Describe the tests you've performed to ensure the functionality is working as expected. -->
Entered invalid email and password to check if the error message is disabled. On register page, entered details to get see success message