### PR TITLE
enhance hotels route with city query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+/.vscode
 
 # scaffold test
 /cypress/e2e/1-getting-started

--- a/src/routes/listings/HotelsSearch.jsx
+++ b/src/routes/listings/HotelsSearch.jsx
@@ -5,7 +5,7 @@ import { networkAdapter } from 'services/NetworkAdapter';
 import isEmpty from 'utils/helpers';
 import { MAX_GUESTS_INPUT_VALUE } from 'utils/constants';
 import { formatDate } from 'utils/date-helpers';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { parse } from 'date-fns';
 
 /**
@@ -50,6 +50,8 @@ const HotelsSearch = () => {
   // State for managing selected filters
   const [selectedFiltersState, setSelectedFiltersState] = useState({});
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const location = useLocation();
 
   /**
@@ -87,6 +89,9 @@ const HotelsSearch = () => {
     const numGuest = Number(numGuestsInputValue);
     const checkInDate = formatDate(dateRange.startDate) ?? '';
     const checkOutDate = formatDate(dateRange.endDate) ?? '';
+    setSearchParams({
+      city: locationInputValue,
+    });
     fetchHotels({
       city: locationInputValue,
       ...activeFilters,
@@ -201,6 +206,13 @@ const HotelsSearch = () => {
     fetchAvailableCities();
     getVerticalFiltersData();
   }, []);
+
+  // And update location input value if city is present in the URL
+  useEffect(() => {
+    if (searchParams.get('city')) {
+      setLocationInputValue(searchParams.get('city'));
+    }
+  }, [searchParams]);
 
   // Update selected filters state when filters data changes
   useEffect(() => {


### PR DESCRIPTION
## Type of Change
- [x] Feat: Preserve City Filter in the URL. 


## Description
This pull request enhances the /hotels page functionality to automatically save the selected city filter as a query parameter in the URL when the user changes it. Additionally, when the user reloads the page and a city filter is present in the URL, the form filter will now dynamically set its value to match the city specified in the URL. This improvement provides users with a more seamless experience when navigating and filtering hotels by city on the website.
I also added .vscode to .gitignore

## Linked Issue
This PR Closes: #47 

## Screenshots
<img width="1070" alt="image" src="https://github.com/iZooGooD/stay-booker-hotel-booking-react-frontend/assets/16366008/be8c651a-82d3-4249-b6a7-8f7e8a7013b3">


## Tests
1. Updating City Filter:

- Change the city filter selection.
- Verify that the city query in the URL updates accordingly.

2. Copy-Pasting URL:

- Copy the URL with the city filter.
- Paste the URL into a new browser tab.
- Verify that the city filter in the form matches the city specified in the URL query.
- Ensure that the list of hotels is filtered based on this city.
