### PR TITLE
Fix register toast dismiss handler

### DIFF
--- a/src/routes/register/Register.jsx
+++ b/src/routes/register/Register.jsx
@@ -20,6 +20,14 @@ const Register = () => {
   const [showToast, setShowToast] = useState(false);
 
   /**
+   * Hides the toast message displayed after form submission.
+   */
+  const dismissToast = () => {
+    setShowToast(false);
+    setToastMessage('');
+  };
+
+  /**
    * Submits the registration form data to the server.
    * It performs an asynchronous operation to post the form data to a registration endpoint.
    * If registration is successful, a success message is displayed, and the user is redirected to the login page after a brief delay.
@@ -136,7 +144,7 @@ const Register = () => {
                     <Toast
                       type={toastType}
                       message={toastMessage}
-                      dismissError
+                      dismissError={dismissToast}
                     />
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- handle toast dismissal on registration page

## Testing
- `npm test` *(fails: 403 Forbidden when installing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684f88508fd08331834ee9bd6891fb43